### PR TITLE
Refactor

### DIFF
--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -4,6 +4,7 @@ const PERMISSION_SEP_OR = ',';
 const PERMISSION_SEP_AND = '&&';
 
 const EventEmitter = require('events');
+const Promise = require('bluebird');
 
 const Provider = require('./provider');
 const AttributesManager = require('./attributes-manager');
@@ -66,37 +67,37 @@ const RBAC = module.exports = class RBAC extends EventEmitter {
 
     permissions = preparePermissionList(permissions);
 
-    return getUserRoles(emitter, user, params, provider, attributes).then(function (userRoles) {
-      return Promise.all(Object.keys(userRoles).map(function (role) {
-        return getRolePermissions(emitter, user, role, userRoles[role], provider);
-      })).then(function (rolePermissionsList) {
-        let priority = NaN;
+    return getUserRoles(emitter, user, params, provider, attributes)
+    .then(function (userRoles) {
+      return getRolesPermissions(emitter, user, userRoles, provider)
+    })
+    .then(function (rolePermissionsList) {
+      let priority = NaN;
 
-        if (rolePermissionsList.length) {
-          for (let i = 0, iLen = permissions.length, permissionGroup, groupPriority; i < iLen; ++i) {
-            permissionGroup = permissions[i];
-            groupPriority = priority;
+      if (rolePermissionsList.length) {
+        for (let i = 0, iLen = permissions.length, permissionGroup, groupPriority; i < iLen; ++i) {
+          permissionGroup = permissions[i];
+          groupPriority = priority;
 
-            for (let j = 0, jLen = permissionGroup.length, permission; j < jLen; ++j) {
-              permission = permissionGroup[j];
+          for (let j = 0, jLen = permissionGroup.length, permission; j < jLen; ++j) {
+            permission = permissionGroup[j];
 
-              for (let k = 0, kLen = rolePermissionsList.length, rolePermissions; k < kLen; ++k) {
-                rolePermissions = rolePermissionsList[k];
+            for (let k = 0, kLen = rolePermissionsList.length, rolePermissions; k < kLen; ++k) {
+              rolePermissions = rolePermissionsList[k];
 
-                if (rolePermissions[permission]) {
-                  groupPriority = Math.min(rolePermissions[permission], groupPriority || Infinity);
-                }
+              if (rolePermissions[permission]) {
+                groupPriority = Math.min(rolePermissions[permission], groupPriority || Infinity);
               }
             }
+          }
 
-            if (groupPriority) {
-              priority = groupPriority;
-            }
+          if (groupPriority) {
+            priority = groupPriority;
           }
         }
+      }
 
-        return priority;
-      });
+      return priority;
     });
   }
 }
@@ -165,9 +166,8 @@ The resolved object has the roles for keys and the role depth as values.
 All unavailable roles are filtered.
 */
 function getUserRoles(emitter, user, params, provider, attributes) {
-  return Promise.resolve().then(function () {
-    return provider.getRoles(user);
-  }).catch(function (err) {
+  return Promise.resolve(provider.getRoles(user))
+  .catch(function (err) {
     err = err || new Error('Error');
     err.role = '*';
     err.user = user;
@@ -200,48 +200,36 @@ Remove any role that are unavailable from the specified attributes.
 This function will directly modify the `roles` object.
 */
 function filterRolesByAttributes(emitter, user, roles, params, provider, attributes) {
-  const validationCache = {};
-
-  function _attr(role) {
-    return validationCache[role] || (validationCache[role] = Promise.resolve().then(function () {
-      return provider.getAttributes(role);
-    }).then(function (roleAttributes) {
-      return roleAttributes && Promise.all(roleAttributes.map(function (attrName) {
-        return Promise.resolve().then(function () {
-          return attributes.validate(attrName, user, role, params);
-        }).catch(function (err) {
-          err = err || new Error('Error');
-          err.role = role;
-          err.user = user;
-
-          emitter.emit('error', err);
-          return false;
-        });
-      })).then(function (results) {
-        for (let i = 0, len = results.length; i < len; ++i) {
-          if (!results[i]) {
-            return true;
-          }
-        }
-      });
-    }));
-  }
 
   function _validate(roles) {
-    return Promise.all(Object.keys(roles).map(function (role) {
-      return _attr(role).then(function (inactive) {
-        if (inactive) {
-          delete roles[role]; // remove role because attribute not available
-        } else if (roles[role] && typeof roles[role] === 'object') {
-          return _validate(roles[role]);
+    return Promise.resolve(provider.getAttributes(Object.keys(roles)))
+    .then(function (roleAttributesByRole) {
+      const roleNames = Object.keys(roleAttributesByRole);
+
+      const activeRoleNames = Promise.filter(roleNames, roleName => {
+        const roleAttributes = roleAttributesByRole[roleName]
+        return Promise.map(roleAttributes, function (attrName) {
+          return attributes.validate(attrName, user, roleName, params);
+        }).then(function (results) {
+          // only return true if all attributes validated
+          return results.every(result => result)
+        });
+      });
+      return Promise.all(activeRoleNames);
+    }).then(function (activeRoleNames) {
+      const result = {};
+      activeRoleNames.forEach(function (roleName) {
+        if (roles[roleName] && typeof roles[roleName] === 'object') {
+          result[roleName] = _validate(roles[roleName])
+        } else {
+          result[roleName] = roles[roleName]
         }
-      })
-    }));
+      });
+      return result;
+    })
   }
 
-  return _validate(roles).then(function () {
-    return roles;
-  });
+  return _validate(roles)
 }
 
 
@@ -249,25 +237,29 @@ function filterRolesByAttributes(emitter, user, roles, params, provider, attribu
 Return all the permission for the given role. The returned value is a lookup
 table of permissions.
 */
-function getRolePermissions(emitter, user, role, priority, provider) {
-  return Promise.resolve().then(function () {
-    return provider.getPermissions(role);
-  }).catch(function (err) {
+function getRolesPermissions(emitter, user, userRoles, provider) {
+  return Promise.resolve(provider.getPermissions(Object.keys(userRoles)))
+  .catch(function (err) {
     err = err || new Error('Error');
     err.role = role;
     err.user = user;
 
     emitter.emit('error', err);
     return null;
-  }).then(function (permissions) {
-    const rolePermissions = {};
+  })
+  .then(function (permissionsByRole) {
+    const roleNames = Object.keys(permissionsByRole);
 
-    if (permissions && Array.isArray(permissions)) {
-      for (let j = 0, jLen = permissions.length; j < jLen; ++j) {
-        rolePermissions[permissions[j]] = priority;
-      }
-    }
+    return roleNames.map(role => {
+      const rolePermissions = {};
+      const permissions = permissionsByRole[role];
+      const priority = userRoles[role];
 
-    return rolePermissions;
+      permissions.forEach(permission => {
+        rolePermissions[permission] = priority;
+      });
+
+      return rolePermissions;
+    });
   });
 }

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -206,13 +206,13 @@ function filterRolesByAttributes(emitter, user, roles, params, provider, attribu
     .then(function (roleAttributesByRole) {
       const roleNames = Object.keys(roleAttributesByRole);
 
-      const activeRoleNames = Promise.filter(roleNames, roleName => {
-        const roleAttributes = roleAttributesByRole[roleName]
+      const activeRoleNames = Promise.filter(roleNames, function (roleName) {
+        const roleAttributes = roleAttributesByRole[roleName];
         return Promise.map(roleAttributes, function (attrName) {
           return attributes.validate(attrName, user, roleName, params);
         }).then(function (results) {
           // only return true if all attributes validated
-          return results.every(result => result)
+          return results.every(function (result) {return result;});
         });
       });
       return Promise.all(activeRoleNames);
@@ -220,16 +220,16 @@ function filterRolesByAttributes(emitter, user, roles, params, provider, attribu
       const result = {};
       activeRoleNames.forEach(function (roleName) {
         if (roles[roleName] && typeof roles[roleName] === 'object') {
-          result[roleName] = _validate(roles[roleName])
+          result[roleName] = _validate(roles[roleName]);
         } else {
-          result[roleName] = roles[roleName]
+          result[roleName] = roles[roleName];
         }
       });
       return result;
     })
   }
 
-  return _validate(roles)
+  return _validate(roles);
 }
 
 
@@ -250,12 +250,12 @@ function getRolesPermissions(emitter, user, userRoles, provider) {
   .then(function (permissionsByRole) {
     const roleNames = Object.keys(permissionsByRole);
 
-    return roleNames.map(role => {
+    return roleNames.map(function (role) {
       const rolePermissions = {};
       const permissions = permissionsByRole[role];
       const priority = userRoles[role];
 
-      permissions.forEach(permission => {
+      permissions.forEach(function (permission) {
         rolePermissions[permission] = priority;
       });
 

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -166,7 +166,7 @@ The resolved object has the roles for keys and the role depth as values.
 All unavailable roles are filtered.
 */
 function getUserRoles(emitter, user, params, provider, attributes) {
-  return Promise.resolve(provider.getRoles(user))
+  return Promise.resolve(provider.getRoles(user, params))
   .catch(function (err) {
     err = err || new Error('Error');
     err.role = '*';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbac-a",
   "description": "RBAC-A dynamic plugin roles implementation",
-  "version": "0.2.5",
+  "version": "1.0.0",
   "author": "Yanick Rochon <yanick.rochon@gmail.com>",
   "keywords": [
     "rbac",


### PR DESCRIPTION
Allow `getPermissions`, `getAttributes` to resolve multiple roles at once. Also, pass in `attributes` to `getRoles` so that it can only get the roles that are used. Improves performance of rbac significantly, in my specific use case from 20+ db calls to only 4-5 db calls.

https://github.com/yanickrochon/rbac-a/issues/4
https://github.com/yanickrochon/rbac-a/issues/5